### PR TITLE
Ignore query params in redirect uri on token endpoint

### DIFF
--- a/lib/osso/routes/oauth.rb
+++ b/lib/osso/routes/oauth.rb
@@ -42,7 +42,7 @@ module Osso
           req.invalid_client! if client.secret != req.client_secret
 
           code = Models::AuthorizationCode.find_by_token!(params[:code])
-          req.invalid_grant! if code.redirect_uri != req.redirect_uri
+          req.invalid_grant! if code.redirect_uri != URI.parse(req.redirect_uri).to_s[/[^?]+/] # TODO: eh
 
           res.access_token = code.access_token.to_bearer_token
         end.call(env)


### PR DESCRIPTION
weird little issue came up in my work on forem where the redirect uri passed as a param to this endpoint includes the code and state, which is not what we persist for the authorization code. 

we _could_ add the code and state params to the redirect_uri persisted on the authorization code here - https://github.com/enterprise-oss/osso-rb/blob/main/lib/osso/lib/saml_handler.rb#L57

But then it won't match what's registered, or what was provided to the authorization URL. this would be, i think, a spec violation