### PR TITLE
Conditional verify account email template

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    osso (0.0.8)
+    osso (0.0.9)
       activesupport (>= 6.0.3.2)
       bcrypt (~> 3.1.13)
       graphql
@@ -115,7 +115,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.0.0)
     rexml (3.2.4)
-    roda (3.38.0)
+    roda (3.39.0)
       rack
     rodauth (2.6.0)
       roda (>= 2.6.0)

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@
 # schema and migrations
 
 ENV['SESSION_SECRET'] ||= 'rake-secret'
+ENV['BASE_URL'] ||= 'https://example.com'
 
 require 'bundler/gem_tasks'
 require 'sinatra/activerecord/rake'

--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+ENV['SESSION_SECRET'] ||= 'irb-secret'
+ENV['BASE_URL'] ||= 'https://example.com'
+
 require 'bundler/setup'
 require 'osso'
 

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,7 +20,9 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      verify_account_email_body DB[:accounts].one? render('verify-first-account-email') : render('verify-account-email')
+      verify_account_email_body = DB[:accounts].one? ? 
+        'verify-first-account-email' : 
+        'verify-account-email'
 
       before_create_account_route do
         request.halt unless DB[:accounts].empty?

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -16,10 +16,15 @@ module Osso
 
     plugin :rodauth do
       enable :login, :verify_account
+      base_uri = URI.parse(ENV.fetch('BASE_URL'))
+      base_url base_uri
+      domain base_uri.host
+
+      email_from { "Osso <no-reply@#{domain}>" }
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      email_from "Osso <no-reply@#{domain}>"
+
 
       verify_account_email_subject do
         DB[:accounts].one? ? 'Your Osso instance is ready' : 'You\'ve been invited to start using Osso'

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,9 +20,9 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
       
-      before_verify_account do
+      after_create_account do
         puts "CREATED ACCOUNT"
-        verify_account_email_body DB[:accounts]&.one? ? 
+        verify_account_view DB[:accounts]&.one? ? 
         'verify-first-account-email' : 
         'verify-account-email'
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -21,14 +21,8 @@ module Osso
       use_database_authentication_functions? false
       
       verify_account_email_body do
-        render('verify-first-account-email')
+        DB[:accounts].one? render('verify-first-account-email') : render('verify-account-email')
       end
-      # after_create_account do
-      #   puts "CREATED ACCOUNT"
-      #   verify_account_view DB[:accounts]&.one? ? 
-      #   'verify-first-account-email' : 
-      #   'verify-account-email'
-      # end
 
       before_create_account_route do
         request.halt unless DB[:accounts].empty?

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,7 +20,7 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
       
-      def verify_account_email_body 
+      verify_account_email_body do
         render('verify-first-account-email')
       end
       # after_create_account do

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,11 +20,11 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      before_create_account do
-        verify_account_email_body = DB[:accounts].empty? ? 
+      
+        verify_account_email_body = DB[:accounts]&.empty? ? 
           'verify-first-account-email' : 
           'verify-account-email'
-      end
+      
 
       before_create_account_route do
         request.halt unless DB[:accounts].empty?

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,7 +19,8 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      
+      email_from "no-reply@#{domain}"
+
       verify_account_email_body do
         DB[:accounts].one? ? render('verify-first-account-email') : render('verify-account-email')
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,7 +20,7 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
       
-      before_setup_account_verification do
+      before_verify_account do
         puts "CREATED ACCOUNT"
         verify_account_email_body DB[:accounts]&.one? ? 
         'verify-first-account-email' : 

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,7 +19,7 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      email_from "no-reply@#{domain}" # TODO: add display name
+      email_from "Osso <no-reply@#{domain}>"
 
       verify_account_email_subject do
         DB[:accounts].one? ? 'Your Osso instance is ready' : 'You\'ve been invited to start using Osso'

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,7 +20,7 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      before_create_verify_account_email do
+      before_send_verify_account_email do
         verify_account_email_body = DB[:accounts].one? ? 
           'verify-first-account-email' : 
           'verify-account-email'

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,13 +19,13 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      
-      after_create_account do
-        puts "CREATED ACCOUNT"
-        verify_account_view DB[:accounts]&.one? ? 
-        'verify-first-account-email' : 
-        'verify-account-email'
-      end
+      verify_account_email_body 'verify-first-account-email'
+      # after_create_account do
+      #   puts "CREATED ACCOUNT"
+      #   verify_account_view DB[:accounts]&.one? ? 
+      #   'verify-first-account-email' : 
+      #   'verify-account-email'
+      # end
 
       before_create_account_route do
         request.halt unless DB[:accounts].empty?

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,12 +19,12 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-
       
-        verify_account_email_body = DB[:accounts]&.empty? ? 
-          'verify-first-account-email' : 
-          'verify-account-email'
-      
+      after_create_account do
+        verify_account_email_body DB[:accounts]&.empty? ? 
+        'verify-first-account-email' : 
+        'verify-account-email'
+      end
 
       before_create_account_route do
         request.halt unless DB[:accounts].empty?

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,7 +19,10 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      verify_account_email_body 'verify-first-account-email'
+      
+      def verify_account_email_body 
+        render('verify-first-account-email')
+      end
       # after_create_account do
       #   puts "CREATED ACCOUNT"
       #   verify_account_view DB[:accounts]&.one? ? 

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,7 +19,7 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      email_from "Osso <no-reply@#{domain}>"
+      email_from "no-reply@#{domain}" # TODO: add display name
 
       verify_account_email_subject do
         DB[:accounts].one? ? 'Your Osso instance is ready' : 'You\'ve been invited to start using Osso'

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -21,7 +21,7 @@ module Osso
       use_database_authentication_functions? false
       
       verify_account_email_body do
-        DB[:accounts].one? render('verify-first-account-email') : render('verify-account-email')
+        DB[:accounts].one? ? render('verify-first-account-email') : render('verify-account-email')
       end
 
       before_create_account_route do

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -21,7 +21,8 @@ module Osso
       use_database_authentication_functions? false
       
       after_create_account do
-        verify_account_email_body DB[:accounts]&.empty? ? 
+        puts "CREATED ACCOUNT"
+        verify_account_email_body DB[:accounts]&.one? ? 
         'verify-first-account-email' : 
         'verify-account-email'
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -25,7 +25,6 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-
       verify_account_email_subject do
         DB[:accounts].one? ? 'Your Osso instance is ready' : 'You\'ve been invited to start using Osso'
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,10 +20,12 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      verify_account_email_body = DB[:accounts].one? ? 
-        'verify-first-account-email' : 
-        'verify-account-email'
-
+      before_verify_account do
+        verify_account_email_body = DB[:accounts].one? ? 
+          'verify-first-account-email' : 
+          'verify-account-email'
+      end
+      
       before_create_account_route do
         request.halt unless DB[:accounts].empty?
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -19,7 +19,11 @@ module Osso
       verify_account_set_password? true
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
-      email_from "no-reply@#{domain}"
+      email_from "Osso <no-reply@#{domain}>"
+
+      verify_account_email_subject do
+        DB[:accounts].one? ? 'Your Osso instance is ready' : 'You\'ve been invited to start using Osso'
+      end
 
       verify_account_email_body do
         DB[:accounts].one? ? render('verify-first-account-email') : render('verify-account-email')

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,7 +20,7 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
       
-      after_create_account do
+      before_setup_account_verification do
         puts "CREATED ACCOUNT"
         verify_account_email_body DB[:accounts]&.one? ? 
         'verify-first-account-email' : 

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,12 +20,12 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      before_verify_account do
+      before_create_verify_account_email do
         verify_account_email_body = DB[:accounts].one? ? 
           'verify-first-account-email' : 
           'verify-account-email'
       end
-      
+
       before_create_account_route do
         request.halt unless DB[:accounts].empty?
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,6 +20,8 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
+      verify_account_email_body DB[:accounts].one? render('verify-first-account-email') : render('verify-account-email')
+
       before_create_account_route do
         request.halt unless DB[:accounts].empty?
       end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -20,8 +20,8 @@ module Osso
       already_logged_in { redirect login_redirect }
       use_database_authentication_functions? false
 
-      before_send_verify_account_email do
-        verify_account_email_body = DB[:accounts].one? ? 
+      before_create_account do
+        verify_account_email_body = DB[:accounts].empty? ? 
           'verify-first-account-email' : 
           'verify-account-email'
       end

--- a/lib/osso/version.rb
+++ b/lib/osso/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Osso
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'
 end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -33,7 +33,7 @@ namespace :osso do
       }))
 
       account = rodauth.account_from_login(admin_email)
-      rodauth.verify_account_email_body('verify-first-account-email')
+      # rodauth.verify_account_email_body('verify-first-account-email')
       rodauth.setup_account_verification
     end
   end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -33,6 +33,7 @@ namespace :osso do
       }))
 
       account = rodauth.account_from_login(admin_email)
+      rodauth.verify_account_email_view = 'verify-first-account-email'
       rodauth.setup_account_verification
     end
   end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -33,7 +33,6 @@ namespace :osso do
       }))
 
       account = rodauth.account_from_login(admin_email)
-      # rodauth.verify_account_email_body('verify-first-account-email')
       rodauth.setup_account_verification
     end
   end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -33,7 +33,7 @@ namespace :osso do
       }))
 
       account = rodauth.account_from_login(admin_email)
-      rodauth.verify_account_email_view = 'verify-first-account-email'
+      rodauth.verify_account_email_view('verify-first-account-email')
       rodauth.setup_account_verification
     end
   end

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -33,7 +33,7 @@ namespace :osso do
       }))
 
       account = rodauth.account_from_login(admin_email)
-      rodauth.verify_account_email_view('verify-first-account-email')
+      rodauth.verify_account_email_body('verify-first-account-email')
       rodauth.setup_account_verification
     end
   end


### PR DESCRIPTION
We use Rodauth's account verification feature to invite the first user when an instance is deployed. We also use the same feature when a user invites a colleague.

We can't really make a single email template fit both use cases, so this allows us to customize the template for the first user compared to subsequent users