### PR TITLE
Add product analytics, track mutations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    osso (0.0.9)
+    osso (0.0.10)
       activesupport (>= 6.0.3.2)
       bcrypt (~> 3.1.13)
       graphql
@@ -9,6 +9,7 @@ PATH
       mail (~> 2.7.1)
       omniauth-multi-provider
       omniauth-saml
+      posthog-ruby
       rack (>= 2.1.4)
       rack-contrib
       rack-oauth2
@@ -66,7 +67,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
-    json-jwt (1.12.0)
+    json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
@@ -94,6 +95,7 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    posthog-ruby (1.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    osso (0.0.10)
+    osso (0.0.11)
       activesupport (>= 6.0.3.2)
       bcrypt (~> 3.1.13)
       graphql

--- a/lib/osso.rb
+++ b/lib/osso.rb
@@ -2,6 +2,7 @@
 
 module Osso
   require_relative 'osso/error/error'
+  require_relative 'osso/lib/analytics'
   require_relative 'osso/lib/app_config'
   require_relative 'osso/lib/oauth2_token'
   require_relative 'osso/lib/route_map'

--- a/lib/osso/graphql/mutations/configure_identity_provider.rb
+++ b/lib/osso/graphql/mutations/configure_identity_provider.rb
@@ -15,7 +15,10 @@ module Osso
         def resolve(**args)
           provider = identity_provider(**args)
 
-          return response_data(identity_provider: provider) if provider.update(args)
+          if provider.update(args)
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(identity_provider: provider) 
+          end
 
           response_error(provider.errors)
         end

--- a/lib/osso/graphql/mutations/create_enterprise_account.rb
+++ b/lib/osso/graphql/mutations/create_enterprise_account.rb
@@ -15,7 +15,10 @@ module Osso
         def resolve(**args)
           enterprise_account = Osso::Models::EnterpriseAccount.new(args)
 
-          return response_data(enterprise_account: enterprise_account) if enterprise_account.save
+          if enterprise_account.save
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(enterprise_account: enterprise_account) 
+          end
 
           response_error(enterprise_account.errors)
         end

--- a/lib/osso/graphql/mutations/create_identity_provider.rb
+++ b/lib/osso/graphql/mutations/create_identity_provider.rb
@@ -22,7 +22,12 @@ module Osso
             oauth_client_id: oauth_client_id,
           )
 
-          return response_data(identity_provider: identity_provider) if identity_provider.save
+          if identity_provider.save
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: {
+              service: service, enterprise_account_id: enterprise_account_id, oauth_client_id: oauth_client_id
+            })
+            return response_data(identity_provider: identity_provider)
+          end  
 
           response_error(identity_provider.errors)
         end

--- a/lib/osso/graphql/mutations/create_oauth_client.rb
+++ b/lib/osso/graphql/mutations/create_oauth_client.rb
@@ -14,7 +14,10 @@ module Osso
         def resolve(**args)
           oauth_client = Osso::Models::OauthClient.new(args)
 
-          return response_data(oauth_client: oauth_client) if oauth_client.save
+          if oauth_client.save
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(oauth_client: oauth_client) 
+          end
 
           response_error(oauth_client.errors)
         end

--- a/lib/osso/graphql/mutations/delete_enterprise_account.rb
+++ b/lib/osso/graphql/mutations/delete_enterprise_account.rb
@@ -18,7 +18,11 @@ module Osso
         def resolve(**args)
           customer = enterprise_account(**args)
 
-          return response_data(enterprise_account: nil) if customer.destroy
+          if customer.destroy
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(enterprise_account: nil) 
+          end
+          
 
           response_error(customer.errors)
         end

--- a/lib/osso/graphql/mutations/delete_identity_provider.rb
+++ b/lib/osso/graphql/mutations/delete_identity_provider.rb
@@ -15,7 +15,7 @@ module Osso
           identity_provider = Osso::Models::IdentityProvider.find(id)
 
           if identity_provider.destroy
-            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: { id: id })
             return response_data(identity_provider: nil) 
           end
 

--- a/lib/osso/graphql/mutations/delete_identity_provider.rb
+++ b/lib/osso/graphql/mutations/delete_identity_provider.rb
@@ -14,7 +14,10 @@ module Osso
         def resolve(id:)
           identity_provider = Osso::Models::IdentityProvider.find(id)
 
-          return response_data(identity_provider: nil) if identity_provider.destroy
+          if identity_provider.destroy
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(identity_provider: nil) 
+          end
 
           response_error(identity_provider.errors)
         end

--- a/lib/osso/graphql/mutations/delete_oauth_client.rb
+++ b/lib/osso/graphql/mutations/delete_oauth_client.rb
@@ -14,7 +14,10 @@ module Osso
         def resolve(id:)
           oauth_client = Osso::Models::OauthClient.find(id)
 
-          return response_data(oauth_client: nil) if oauth_client.destroy
+          if oauth_client.destroy
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: { id: id })
+            return response_data(oauth_client: nil)
+          end
 
           response_error(oauth_client.errors)
         end

--- a/lib/osso/graphql/mutations/invite_admin_user.rb
+++ b/lib/osso/graphql/mutations/invite_admin_user.rb
@@ -23,6 +23,12 @@ module Osso
           if admin_user.save
             verify_user(email)
 
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: {
+              invited_email: email,
+              invited_role: role,
+              invited_oauth_client_id: oauth_client_id,
+            })
+
             return response_data(admin_user: admin_user)
           end
 

--- a/lib/osso/graphql/mutations/regenerate_oauth_credentials.rb
+++ b/lib/osso/graphql/mutations/regenerate_oauth_credentials.rb
@@ -15,7 +15,10 @@ module Osso
           oauth_client = Osso::Models::OauthClient.find(id)
           oauth_client.regenerate_secrets!
 
-          return response_data(oauth_client: oauth_client) if oauth_client.save
+          if oauth_client.save
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: { oauth_client_id: id })
+            return response_data(oauth_client: oauth_client)
+          end
 
           response_error(oauth_client.errors)
         end

--- a/lib/osso/graphql/mutations/set_redirect_uris.rb
+++ b/lib/osso/graphql/mutations/set_redirect_uris.rb
@@ -18,6 +18,8 @@ module Osso
           update_existing(oauth_client, redirect_uris)
           create_new(oauth_client, redirect_uris)
 
+          Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: redirect_uris)
+
           response_data(oauth_client: oauth_client.reload)
         rescue StandardError => e
           response_error(e)

--- a/lib/osso/graphql/mutations/update_app_config.rb
+++ b/lib/osso/graphql/mutations/update_app_config.rb
@@ -15,7 +15,10 @@ module Osso
 
         def resolve(**args)
           app_config = Osso::Models::AppConfig.find
-          return response_data(app_config: app_config) if app_config.update(**args)
+          if app_config.update(**args)
+            Osso::Analytics.capture(email: context[:email], event: self.class.name.demodulize, properties: args)
+            return response_data(app_config: app_config)
+          end
 
           response_error(app_config.errors)
         end

--- a/lib/osso/lib/analytics.rb
+++ b/lib/osso/lib/analytics.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'posthog-ruby'
+
+module Osso
+  # Osso::Analytics provides an interface to track product analytics for any provider.
+  # Osso recommends PostHog as an open source solution for your product analytics needs.
+  # If you want to use another product analytics provider, you can patch the Osso::Analytics 
+  # class yourself in your parent application. Be sure to implement the public
+  # .identify and .capture class methods with the required method signatures and require 
+  # your class after requiring Osso.
+  class Analytics
+    class << self
+      def identify(email:, properties: {})
+        return unless configured?
+
+        client.identify({
+          distinct_id: email,
+          properties: properties.merge(instance_properties),
+        })
+      end
+
+      def capture(email:, event:, properties: {})
+        return unless configured?
+
+        client.capture(
+          distinct_id: email,
+          event: event,
+          properties: properties.merge(instance_properties),
+        )
+      end
+
+      private
+
+      def configured?
+        ENV['POSTHOG_API_KEY'].present?
+      end
+
+      def client
+        @client ||= PostHog::Client.new({
+          api_key: ENV['POSTHOG_API_KEY'],
+          api_host: ENV['POSTHOG_HOST'],
+          on_error: Proc.new { |status, msg| print msg }
+        })
+      end
+
+      def instance_properties
+        {
+          instance_url: ENV['BASE_URL'],
+          osso_plan: ENV['OSSO_PLAN'],
+        }
+      end
+    end
+  end
+end

--- a/lib/osso/routes/admin.rb
+++ b/lib/osso/routes/admin.rb
@@ -29,6 +29,10 @@ module Osso
       verify_account_set_password? true
       use_database_authentication_functions? false
 
+      after_login do
+        Osso::Analytics.identify(email: account[:email], properties: account)
+      end
+
       verify_account_view do
         render :admin
       end

--- a/lib/osso/version.rb
+++ b/lib/osso/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Osso
-  VERSION = '0.0.10'
+  VERSION = '0.0.11'
 end

--- a/osso-rb.gemspec
+++ b/osso-rb.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mail', '~> 2.7.1'
   spec.add_runtime_dependency 'omniauth-multi-provider'
   spec.add_runtime_dependency 'omniauth-saml'
+  spec.add_runtime_dependency 'posthog-ruby'
   spec.add_runtime_dependency 'rack', '>= 2.1.4'
   spec.add_runtime_dependency 'rack-contrib'
   spec.add_runtime_dependency 'rack-oauth2'


### PR DESCRIPTION
This adds an analytics interface for tracking product level events, and calls the interface from all of our graphql mutations.

The goal is to allow implementers to use any service they choose. This first pass defaults to PostHog (useful for us internally and with paid instances) but can be subclassed by implementers for other providers with a pretty standard interface.

We might consider creating delegate classes here for popular providers - so depending on which subclass services are configured via env vars, delegating the `track` and `capture` methods to those. That way we can support varying providers without any extra work on the implementer's end. 